### PR TITLE
add a stylus document that imports something with a local path to tests

### DIFF
--- a/spec/testapp/app.coffee
+++ b/spec/testapp/app.coffee
@@ -16,6 +16,7 @@ css.bind app
 css.addFile __dirname + "/stylesheets/style.css"
 css.addFile "namespaced", __dirname + "/stylesheets/namespaced.css"
 css.addFile __dirname + "/stylesheets/style.styl"
+css.addFile __dirname + "/stylesheets/import.styl"
 css.addFile __dirname + "/stylesheets/style.less"
 css.addRaw "#raw { display: none }"
 

--- a/spec/testapp/stylesheets/import.styl
+++ b/spec/testapp/stylesheets/import.styl
@@ -1,0 +1,1 @@
+@import "style.styl"


### PR DESCRIPTION
Sorry about the other pull request, I wasn't sure whether I was going to continue with some changes or not.

I added a stylus document that imports the current style.styl test document using a local path to the test app, the app fails to load if the import fails and causes a bunch of other failures. Not that great, but passes if imports are working. Trying to think of a better way to test specifically.
