### PR TITLE
filepath fix for windows

### DIFF
--- a/lib/piler.coffee
+++ b/lib/piler.coffee
@@ -49,7 +49,10 @@ asCodeOb = do ->
     hash = sum.digest('hex').substring 10, 0
 
     if @type  in ["file", "module"]
-      filename = _.last @filePath.split("/")
+      if @filePath.indexOf("\\") >= 0
+        filename = _.last @filePath.split("\\")
+      else
+        filename = _.last @filePath.split("/")
       filename = filename.replace /\./g, "_"
       filename = filename.replace /\-/g, "_"
       hash = filename + "_" + hash


### PR DESCRIPTION
Unfortunately, when running on windows and using addFile the path normalization results with back slashes...
so the getId function will not work properly... :-(

But if you fix it like this it will work better... :-)
