### PR TITLE
Using Stylus: filename is not defined

### DIFF
--- a/lib/compilers.coffee
+++ b/lib/compilers.coffee
@@ -32,7 +32,7 @@ compilers =
 if stylus?
   compilers.styl =
     targetExt: "css"
-    render: (code, cb) ->
+    render: (filename, code, cb) ->
       stylus(code)
       .set('filename', filename)
       .render cb


### PR DESCRIPTION
Scenario:
- Deliver .styl files

Steps to reproduce:
- Install stylus
- Add core.styl file
- Use core.styl file with clientcss.addFile

Expected result:
- The .styl file is parsed and deliver as CSS

Actual result:
- When the application is started, an error occurs: "filename is not defined" in compilers.coffee:51

Solution:
- The stylus' compiler render method was missing a filename parameter, added it.
