### PR TITLE
Express 3 compatibility (fixes #26)

### DIFF
--- a/lib/piler.coffee
+++ b/lib/piler.coffee
@@ -300,11 +300,12 @@ class PileManager
       tags += "\n"
     return tags
 
-  bind: (app) ->
+  bind: (app, server=null) ->
 
     @app = app
 
-    app.on "listening", =>
+    listener = if server then server else app
+    listener.on "listening", =>
       @pileUp()
 
 


### PR DESCRIPTION
In Express.js 3, application objects aren't `http.Server` instances anymore so doing `app.on("listening"...)` in the `PileManager.bind` method will do nothing. To make piler compatible with Express 3 you have to pass the http.Server as a separate parameter and bind to this.
