### PR TITLE
Work-in-progress: Add the ability to manage templates

### DIFF
--- a/lib/minify.coffee
+++ b/lib/minify.coffee
@@ -4,6 +4,7 @@
 #
 
 csso = require "csso"
+htmlMin = require "html-minifier"
 
 try
   uglify = require("uglify-js")
@@ -15,7 +16,12 @@ catch error
 
 
 exports.cssMinify = (code) -> csso.justDoIt code
-
+exports.htmlMinify = (code) ->
+  htmlMin.minify code,
+    removeComments: true
+    collapseBooleanAttributes: true
+    collapseWhitespace: true
+    removeRedundantAttributes: true
 
 
 if uglify?

--- a/lib/piler.coffee
+++ b/lib/piler.coffee
@@ -247,14 +247,8 @@ class TemplatePile extends BasePile
 
     # Start with plain urls
     sources = ([u] for u in @urls)
-    
-    if @production
-      for ob in @code
-        sources.push [ ob.id, getCompiler(ob.filePath) ob.filePath, data ]
-    else
-      for ob in @code
-        ob.data = data
-        sources.push ["#{ @urlRoot }dev/#{ devCacheKey }/#{ @name }.#{ ob.type }-#{ ob.getId() }.#{ @ext }", "id=\"#{ ob.id }\""]
+    for ob in @code
+      sources.push [ ob.id, getCompiler(ob.filePath) ob.filePath, data ]
     return sources
 
 
@@ -475,10 +469,7 @@ class TemplateManager extends PileManager
   contentType: "text/html"
 
   wrapInTag: (uri, extra="") ->
-    if @production
-      "<script type=\"text/#{ @settings.templateType }\" id=\"#{ uri }\">#{ extra }</script>"
-    else
-      "<script type=\"text/#{ @settings.templateType }\" src=\"#{ uri }\" #{ extra }></script>"
+    "<script type=\"text/#{ @settings.templateType }\" id=\"#{ uri }\">#{ extra }</script>"
 
   getSources: (namespaces...) ->
     if typeof _.last(namespaces) is "object"

--- a/lib/piler.coffee
+++ b/lib/piler.coffee
@@ -261,6 +261,9 @@ class PileManager
     pile = @getPile ns
     pile.addFile path
 
+  addFiles: (ns, arr) ->
+    addFile(ns, file) for file in arr
+
   addRaw: defNs (ns, raw) ->
     pile = @getPile ns
     pile.addRaw raw

--- a/lib/piler.coffee
+++ b/lib/piler.coffee
@@ -11,6 +11,7 @@ OB = require "./serialize"
 compilers = require "./compilers"
 assetUrlParse = require "./asseturlparse"
 logger = require "./logger"
+walker = require "./walker"
 
 toGlobals = (globals) ->
   code = ""
@@ -106,6 +107,10 @@ class BasePile
         type: "file"
         filePath: filePath
 
+  addDir: (dir, patterns) ->
+    dir = path.normalize dir
+    @warnPiledUp "addDir"
+    @addFile file for file in walker.walk dir, patterns
 
   addRaw: (raw) ->
     @warnPiledUp "addRaw"
@@ -277,8 +282,16 @@ class PileManager
     pile = @getPile ns
     pile.addFile path
 
-  addFiles: (ns, arr) ->
-    addFile(ns, file) for file in arr
+  addFiles: (ns, files) ->
+    addFile(ns, file) for file in files
+
+  addDir: (ns, dir, patterns) ->
+    if arguments.length is 1 or (arguments.length is 2 and _(arguments[1]).isArray())
+      patterns = dir or []
+      dir = ns
+      ns = "global"
+    pile = @getPile ns
+    pile.addDir dir, patterns
 
   addRaw: defNs (ns, raw) ->
     pile = @getPile ns

--- a/lib/piler.coffee
+++ b/lib/piler.coffee
@@ -229,7 +229,7 @@ class TemplatePile extends BasePile
 
   addOb: (ob) ->
     @warnPiledUp "addTmpl"
-    @code.push(id: id, tmpl: tmpl) for id, tmpl of ob
+    @code.push(id: id, tmpl: val) for id, val of ob
 
   getSources: ->
     for ob in @code
@@ -455,7 +455,10 @@ class TemplateManager extends PileManager
   contentType: "text/html"
 
   wrapInTag: (id, tmpl) ->
-    "<script type=\"text/#{@settings.templateType}\" id=\"#{id}\">#{tmpl}</script>"
+    if /[<>]/.test(tmpl)
+      "<script type=\"text/#{@settings.templateType}\" src=\"#{tmpl}\" id=\"#{id}\"></script>"
+    else
+      "<script type=\"text/#{@settings.templateType}\" id=\"#{id}\">#{tmpl}</script>"
 
   setMiddleware: (app) ->
 

--- a/lib/walker.coffee
+++ b/lib/walker.coffee
@@ -19,6 +19,10 @@ walk = (dir, prefix) ->
 module.exports =
   walk: (dir, patterns) ->
     files = walk dir
-    return if not patterns then files else _.chain(patterns).reduce((memo, pattern) ->
+    files = if not patterns then files else _.chain(patterns).reduce((memo, pattern) ->
       memo.concat files.filter minimatch.filter pattern
     , []).uniq().value()
+    return _(files).reduce (memo, file) ->
+      memo.push("#{dir}/#{file}")
+      memo
+    , []

--- a/lib/walker.coffee
+++ b/lib/walker.coffee
@@ -1,0 +1,24 @@
+fs = require "fs"
+minimatch = require "minimatch"
+_ = require "underscore"
+
+readByKind = (dir) ->
+  files = fs.readdirSync dir
+  _(files).groupBy (file) ->
+    stat = fs.statSync "#{dir}/#{file}"
+    if stat.isDirectory() then "directories" else if stat.isFile() then "files" else "other"
+
+walk = (dir, prefix) ->
+  prefix = if prefix then "#{prefix}/" else ""
+  descriptors = readByKind dir
+  _(descriptors.directories).reduce (memo, directory) ->
+    memo.concat(walk "#{dir}/#{directory}", "#{prefix}#{directory}")
+  , _(descriptors.files).map (file) ->
+    "#{prefix}#{file}"
+
+module.exports =
+  walk: (dir, patterns) ->
+    files = walk dir
+    return if not patterns then files else _.chain(patterns).reduce((memo, pattern) ->
+      memo.concat files.filter minimatch.filter pattern
+    , []).uniq().value()

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "underscore.string": "2.2.0rc",
     "uglify-js": "1.3.x",
     "async": "0.1.22",
-    "csso": "1.2.x"
+    "csso": "1.2.x",
+    "html-minifier": "0.5.x"
   },
   "devDependencies": {
     "jasmine-node": "",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "uglify-js": "1.3.x",
     "async": "0.1.22",
     "csso": "1.2.x",
-    "html-minifier": "0.5.x"
+    "html-minifier": "0.5.x",
+    "minimatch": "0.2.x"
   },
   "devDependencies": {
     "jasmine-node": "",


### PR DESCRIPTION
So this started because I'm using piler and angular.js and wanted to cache my angular templates on the client side. Adding

``` html
<script type="text/ng-template" id="template/name.html">
  Contents of template
</script>
```

will tell angular to add them to $templateCache. So I wanted a TemplatePile that would just let me add a series of angular templates and render them automatically.

So there's a new TemplatePile and a TemplateManager, but I wrote them to work with other templating engines too (interesting side effect is that you could write your angular templates in jade and compile them on the server side and let piler render them on the client side).

I added a couple helpers too: an addFiles method that let's you pass an array of files to a pile manager, and an addDir method that let's you read all the files (recursively) from a directory (optionally filtered with globstar patterns). I thought about trying to use the asynchronous fs methods for this, but you probably don't want to have to do

``` javascript
clientjs.addDir('some/dir', function(err) {
  // Now we know we can safely call res.end
  // but it feels wrong to do it here . . .
});
```

So I went with sync, figuring that most people who are going to pull in a whole directory, will probably do so on app initialization and not per request.

This is still sort of a work in progress (untested and no tests), but I wanted to get some feedback to see if this is worth continuing to pursue (or to see if you have any additional thoughts/comments).

Thanks.
