### PR TITLE
added support for absolute doomain urlRoot for cdn support

### DIFF
--- a/lib/piler.coffee
+++ b/lib/piler.coffee
@@ -320,8 +320,8 @@ class PileManager
 
 
     app.use (req, res, next) =>
-
-      if not _.startsWith req.url, @settings.urlRoot
+      url = @settings.urlRoot.replace(/^.*\/\/[^\/]+/, '')
+      if not _.startsWith req.url, url
         return next()
 
       res.setHeader "Content-type", @contentType


### PR DESCRIPTION
I have my css and js assets on http://cdn.<mydomain>.com/assest and would like to be able to define an absolute urlRoot in the maanger.
